### PR TITLE
Fix install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,1 @@
-anyjson
-redis
-argparse
-carrot
-eventlet
-python-dateutil
-feedgenerator
-httplib2
-PubSubHubbub_Publisher
-requests
-routes
-WebOb
-python-daemon
-BeautifulSoup
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,9 @@
 import os
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-
-req_file = os.path.join(os.path.dirname(__file__), "requirements.txt")
-install_reqs = [str(r.req) for r in parse_requirements(req_file)]
-
 
 setup(
     name='yagi',
@@ -31,6 +25,21 @@ setup(
     url='https://github.com/Cerberus98/yagi',
     scripts=['bin/yagi-feed', 'bin/yagi-event'],
     long_description=read('README.md'),
-    install_requires=install_reqs,
+    install_requires=[
+        "anyjson",
+        "redis",
+        "argparse",
+        "carrot",
+        "eventlet",
+        "python-dateutil",
+        "feedgenerator",
+        "httplib2",
+        "PubSubHubbub_Publisher",
+        "requests",
+        "routes",
+        "WebOb",
+        "python-daemon",
+        "BeautifulSoup",
+    ],
     zip_safe=False
 )


### PR DESCRIPTION
See https://caremad.io/2013/07/setup-vs-requirement/ for more info
* Move list of requirements to setup.py
* Remove use of parse_requirements() which changed in latest pip release