### PR TITLE
Extend shoebox_handler to support other RollManagers.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,5 @@
 mox
+mock
 nose
+notification_utils
+shoebox

--- a/tests/unit/test_shoebox_handler.py
+++ b/tests/unit/test_shoebox_handler.py
@@ -43,8 +43,13 @@ class TestShoeboxHandler(unittest.TestCase):
 
     def test_json_roll_manager(self):
         config.config = mock.MagicMock()
-        config.config.return_value = {
-                'roll_manager': 'shoebox.roll_manager:WritingJSONRollManager'}
-        sh = shoebox_handler.ShoeboxHandler()
-        self.assertTrue(sh.roll_manager is not None)
+        config.config.items.return_value = {
+                'working_directory': 'foo',
+                'roll_manager':
+                    'shoebox.roll_manager:WritingJSONRollManager'}.items()
+        with mock.patch.object(shoebox_handler.os.path, "isdir") as isdir:
+            isdir.return_value = True
+            sh = shoebox_handler.ShoeboxHandler()
+            self.assertTrue(sh.roll_manager is not None)
+            self.assertEquals(sh.roll_manager.directory, 'foo')
 

--- a/tests/unit/test_shoebox_handler.py
+++ b/tests/unit/test_shoebox_handler.py
@@ -1,0 +1,50 @@
+import mock
+import unittest
+
+from yagi import config
+
+from yagi.handler import shoebox_handler
+
+
+class Fake(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class TestShoeboxHandler(unittest.TestCase):
+    def test_init(self):
+        config.config = mock.MagicMock()
+        config.config.items.return_value = ()
+        sh = shoebox_handler.ShoeboxHandler()
+
+        self.assertTrue(sh.roll_checker is None)
+        self.assertEqual(sh.working_directory, '.')
+        self.assertEqual(sh.destination_folder, '.')
+        self.assertTrue(sh.roll_manager is not None)
+
+    def test_init_full(self):
+        config.config = mock.MagicMock()
+        config.config.items.return_value = {
+            'roll_checker': 'tests.unit.test_shoebox_handler:Fake',
+            'working_directory': 'foo',
+            'destination_folder': 'blah',
+            'filename_template': 'mytemplate',
+            'callback': 'tests.unit.test_shoebox_handler:Fake',
+            'roll_manager': 'tests.unit.test_shoebox_handler:Fake',
+        }.items()
+        with mock.patch.object(shoebox_handler.os.path, "isdir") as isdir:
+            isdir.return_value = True
+            sh = shoebox_handler.ShoeboxHandler()
+            self.assertTrue(sh.roll_checker is not None)
+            self.assertEqual(sh.working_directory, 'foo')
+            self.assertEqual(sh.destination_folder, 'blah')
+            self.assertTrue(sh.roll_manager is not None)
+
+    def test_json_roll_manager(self):
+        config.config = mock.MagicMock()
+        config.config.return_value = {
+                'roll_manager': 'shoebox.roll_manager:WritingJSONRollManager'}
+        sh = shoebox_handler.ShoeboxHandler()
+        self.assertTrue(sh.roll_manager is not None)
+

--- a/yagi/handler/shoebox_handler.py
+++ b/yagi/handler/shoebox_handler.py
@@ -43,8 +43,8 @@ class ShoeboxHandler(yagi.handler.BaseHandler):
                                     'shoebox.roll_manager:WritingRollManager')
 
         self.roll_manager = simport.load(roll_manager_str)(template,
-                                self.roll_checker, self.working_directory,
-                                archive_callback=cb)
+                        self.roll_checker, directory=self.working_directory,
+                        archive_callback=cb)
 
     def handle_messages(self, messages, env):
         # TODO(sandy): iterate_payloads filters messages first ... not

--- a/yagi/handler/shoebox_handler.py
+++ b/yagi/handler/shoebox_handler.py
@@ -23,8 +23,10 @@ class ShoeboxHandler(yagi.handler.BaseHandler):
         super(ShoeboxHandler, self).__init__(app, queue_name)
         # Don't use interpolation from ConfigParser ...
         self.config = dict(yagi.config.config.items('shoebox', raw=True))
-        roll_checker_str = self.config['roll_checker']
-        self.roll_checker = simport.load(roll_checker_str)(**self.config)
+        roll_checker_str = self.config.get('roll_checker')
+        self.roll_checker = None
+        if roll_checker_str:
+            self.roll_checker = simport.load(roll_checker_str)(**self.config)
         self.working_directory = self.config.get('working_directory', '.')
         self.destination_folder = self.config.get('destination_folder', '.')
         for d in [self.working_directory, self.destination_folder]:
@@ -32,8 +34,15 @@ class ShoeboxHandler(yagi.handler.BaseHandler):
                 os.makedirs(d)
         template=self.config.get('filename_template',
                                  'events_%Y_%m_%d_%X_%f.dat')
-        cb = simport.load(self.config['callback'])(**self.config)
-        self.roll_manager = roll_manager.WritingRollManager(template,
+        callback_str = self.config.get('callback')
+        cb = None
+        if callback_str:
+            cb = simport.load(callback_str)(**self.config)
+
+        roll_manager_str = self.config.get('roll_manager',
+                                    'shoebox.roll_manager:WritingRollManager')
+
+        self.roll_manager = simport.load(roll_manager_str)(template,
                                 self.roll_checker, self.working_directory,
                                 archive_callback=cb)
 


### PR DESCRIPTION
Such as the WritingJSONRollManager. Also adds some unit tests
for this handler. Note that the requirements for this handler
are in test-requirements as we don't expect every yagi
deployment to need notification_utils or shoebox.