### PR TITLE
Improve logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name='yagi',
-    version='0.17',
+    version='0.18',
     author='Matthew Dietz, Monsyne Dragon',
     author_email='matthew.dietz@gmail.com, mdragon@rackspace.com',
     description=("A PubSubHubBub Publisher and ATOM feed generator that "

--- a/yagi/log.py
+++ b/yagi/log.py
@@ -36,6 +36,13 @@ class YagiLogger(logging.Logger):
 
 def setup_logging():
     config_file = yagi.config.get('logging', 'config_file')
+    default_log_level = logging.getLevelName(yagi.config.get('logging', 'default_level'))
+
+    # This is a hack, but it's needed to pass the logfile name & default
+    # loglevel into log handlers configured with a config file. (mdragon)
+    logging.LOCAL_LOG_FILE = config_file
+    logging.LOCAL_DEFAULT_LEVEL = default_log_level
+
     if config_file:
         #if a logging configfile exists, it overrides everything else.
         fileConfig(config_file)


### PR DESCRIPTION
Allow yagi to specify logfile name in yagi.conf when using logging.conf
to avoid having a separate logging.conf for each process.