### PR TITLE
shoebox handler can wrap notifications with region/cell info.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name='yagi',
-    version='0.22',
+    version='0.23',
     author='Matthew Dietz, Monsyne Dragon',
     author_email='matthew.dietz@gmail.com, mdragon@rackspace.com',
     description=("A PubSubHubBub Publisher and ATOM feed generator that "

--- a/yagi/handler/shoebox_handler.py
+++ b/yagi/handler/shoebox_handler.py
@@ -42,6 +42,12 @@ class ShoeboxHandler(yagi.handler.BaseHandler):
         roll_manager_str = self.config.get('roll_manager',
                                     'shoebox.roll_manager:WritingRollManager')
 
+        self.wrap_payload_with_region = self.config.get(
+                            'wrap_payload_with_region', 'False') == 'True'
+
+        self.region = self.config.get('wrap_region', 'n/a')
+        self.cell = self.config.get('wrap_cell', 'n/a')
+
         # Hack(sandy): These sorts of parameters should be left to the
         # callback handlers. Just need it here to get over the hump.
         # Needs to be refactored.
@@ -57,6 +63,9 @@ class ShoeboxHandler(yagi.handler.BaseHandler):
         # sure if we want that for raw archiving.
         for payload in self.iterate_payloads(messages, env):
             metadata = {}
+            if self.wrap_payload_with_region:
+                payload = {'region': self.region, 'cell': self.cell,
+                           'notification': payload}
             json_event = json.dumps(payload,
                                     cls=notification_utils.DateTimeEncoder)
             LOG.debug("shoebox writing payload: %s" % str(payload))


### PR DESCRIPTION
If config 'wrap_payload_with_region' is True, then
notification will take the form:

{'region': config['wrap_region'],
 'cell': config['wrap__cell'],
 'notification': original_notification}

This will inject the region/cell information without tainting
the original notification.