### PR TITLE
Add Elasticsearch handler and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ of notification events that have been persisted in a datastore.
                  of the success or failure of the updates, letting you 
                  catch if the feed server is down, or some system is 
                  dropping events.
+* Elasticsearch: Persists distilled compute.instance.exists, .verified, and
+                 .failed events to Elasticsearch. Additionally if the CufPub
+                 handler is present earlier in the chain pushes synthetic
+                 .cuf events as well in response to successful CufPub events.
 
 ## Installation and running
 

--- a/tests/unit/event_definitions.yaml
+++ b/tests/unit/event_definitions.yaml
@@ -1,0 +1,122 @@
+---
+- event_type: compute.instance.*
+  traits: &instance_traits
+    tenant_id:
+      fields:
+        - payload.tenant_id
+        - _context_project_id
+    user_id:
+      fields: payload.user_id
+    request_id:
+      fields: _context_request_id
+    message: 
+      fields: payload.message
+    instance_id:
+      fields:
+        - payload.instance_uuid
+        - payload.instance_id
+        - exception.kwargs.uuid
+        - instance.uuid
+    host:
+      fields: publisher_id
+      plugin:
+        name: split
+        parameters:
+          segment: 1
+          max_split: 1
+    service:
+      fields: publisher_id
+      plugin: split
+    instance_flavor:
+      fields: 
+        - payload.instance_type
+        - payload.image_meta.instance_type_name
+        - payload.image_meta.instance_type_flavorid
+        - payload.instance_flavor_id
+    instance_flavor_id:
+      type: int
+      fields: 
+        - payload.image_meta.instance_type_flavor_id
+        - payload.instance_type_id
+    memory_mb:
+      type: int
+      fields: payload.memory_mb
+    disk_gb:
+      type: int
+      fields: payload.disk_gb
+    root_gb:
+      type: int
+      fields: payload.root_gb
+    ephemeral_gb:
+      type: int
+      fields: payload.ephemeral_gb
+    vcpus:
+      type: int
+      fields: payload.vcpus
+    instance_type:
+      fields: payload.instance_type
+    state:
+      fields: payload.state
+    state_description:
+      fields: payload.state_description
+    bandwidth_in:
+      fields: payload.bandwidth.public.bw_in
+    bandwidth_out:
+      fields: payload.bandwidth.public.bw_out
+    os_architecture:
+      fields: payload.image_meta.'org.openstack__1__architecture'
+    os_version:
+      fields: payload.image_meta.'org.openstack__1__os_version'
+    os_distro:
+      fields: payload.image_meta.'org.openstack__1__os_distro'
+    rax_options:
+      fields: payload.image_meta.'com.rackspace__1__options'
+    launched_at:
+      type: datetime
+      fields: payload.launched_at
+    deleted_at:
+      type: datetime
+      fields: 
+        - payload.deleted_at
+        - payload.terminated_at
+    display_name:
+      fields: payload.display_name
+
+- event_type: compute.instance.exists.*
+  traits:
+    <<: *instance_traits
+    audit_period_beginning:
+      type: datetime
+      fields: payload.audit_period_beginning
+    audit_period_ending:
+      type: datetime
+      fields: payload.audit_period_ending
+    error:
+      fields: error
+    error_code:
+      fields: error_code
+    original_message_id:
+      fields: original_message_id
+
+- event_type: compute.instance.exists
+  traits:
+    <<: *instance_traits
+    audit_period_beginning:
+      type: datetime
+      fields: payload.audit_period_beginning
+    audit_period_ending:
+      type: datetime
+      fields: payload.audit_period_ending
+
+- event_type: snapshot_instance
+  traits:
+    <<: *instance_traits
+- event_type: scheduler.run_instance.*
+  traits:
+    <<: *instance_traits
+- event_type: keypair.import.*
+  traits:
+    <<: *instance_traits
+- event_type: rebuild_instance
+  traits:
+    <<: *instance_traits

--- a/tests/unit/test_elasticsearch_handler.py
+++ b/tests/unit/test_elasticsearch_handler.py
@@ -1,0 +1,226 @@
+import copy
+import datetime
+import functools
+import json
+import requests
+import unittest
+import uuid
+
+import mock
+
+import stackdistiller.distiller
+import yagi.config
+from yagi.handler import elasticsearch_handler
+
+
+class MockMessage(object):
+    def __init__(self, payload):
+        self.payload = payload
+        self.acknowledged = False
+
+    def ack(self):
+        self.acknowledged = True
+
+
+class TestDateEncoder(unittest.TestCase):
+    def test_date_encoder(self):
+        dt = datetime.datetime(2015, 5, 4, 3, 30, 41, 569321)
+        expected = 1430710241569
+        encoder = elasticsearch_handler.ElasticsearchDateEncoder()
+        ms = encoder.default(dt)
+        self.assertEqual(expected, ms)
+
+    def test_date_encoder_json(self):
+        dt = datetime.datetime(2015, 5, 4, 3, 30, 41, 569321)
+        d = dict(timestamp=dt)
+        j = json.dumps(d, cls=elasticsearch_handler.ElasticsearchDateEncoder)
+        expected = '{"timestamp": 1430710241569}'
+        self.assertEqual(expected, j)
+
+
+class TestElasticsearchHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.patches = []
+        self.region = 'preprod'
+        self.elasticsearch_host = \
+            'http://127.0.0.1:9200/abacus/serverUsageEvents'
+        self.distiller_config = 'event_definitions.yaml'
+        config_dict = {
+            'elasticsearch': {
+                'region': self.region,
+                'elasticsearch_host': self.elasticsearch_host,
+                'distiller_config': self.distiller_config,
+            },
+        }
+
+        def get(*args, **kwargs):
+            val = None
+            for arg in args:
+                if val:
+                    val = val.get(arg)
+                else:
+                    val = config_dict.get(arg)
+                    if not val:
+                        return None or kwargs.get('default')
+            return val
+
+        def config_with(*args):
+            return functools.partial(get, args)
+
+        self.patches.append(mock.patch.object(yagi.config, 'config_with',
+                                              new=config_with))
+        self.patches.append(mock.patch.object(yagi.config, 'get', new=get))
+
+        self.post_args = []
+
+        def post(url, data=None, json=None, **kwargs):
+            self.post_args.append({
+                'url': url,
+                'data': data,
+                'json': json
+            })
+
+        self.patches.append(mock.patch.object(requests, 'post', new=post))
+        for patch in self.patches:
+            patch.start()
+
+        self.handler = elasticsearch_handler.ElasticsearchHandler()
+
+    def tearDown(self):
+        for patch in self.patches:
+            patch.stop()
+
+    def test_init(self):
+        self.assertEqual(self.region, self.handler.region)
+        self.assertEqual(self.elasticsearch_host,
+                         self.handler.elasticsearch_host)
+        self.assertIsInstance(self.handler.distiller,
+                              stackdistiller.distiller.Distiller)
+
+    def test_send_to_elasticsearch_exists(self):
+        begin = datetime.datetime(2015, 5, 3, 0, 0, 0, 0)
+        end = datetime.datetime(2015, 5, 4, 0, 0, 0, 0)
+        now = datetime.datetime.utcnow()
+        message_id = str(uuid.uuid4())
+
+        event = {
+            'event_type': 'compute.instance.exists',
+            'message_id': message_id,
+            'audit_period_beginning': begin,
+            'audit_period_ending': end,
+            'when': now
+        }
+
+        expected = copy.copy(event)
+        expected['region'] = self.region
+        expected['@timestamp'] = end
+        exp_json = json.dumps(
+            expected, cls=elasticsearch_handler.ElasticsearchDateEncoder)
+        expected = json.loads(exp_json)
+
+        self.handler._send_to_elasticsearch(event)
+
+        args = self.post_args[0]
+        self.assertEqual(self.elasticsearch_host, args['url'])
+        actual = json.loads(args['data'])
+        self.assertDictEqual(expected, actual)
+
+    def test_send_to_elasticsearch_other(self):
+        begin = datetime.datetime(2015, 5, 3, 0, 0, 0, 0)
+        end = datetime.datetime(2015, 5, 4, 0, 0, 0, 0)
+        now = datetime.datetime.utcnow()
+        message_id = str(uuid.uuid4())
+        original_message_id = str(uuid.uuid4())
+
+        event = {
+            'event_type': 'compute.instance.exists.verified',
+            'message_id': message_id,
+            'original_message_id': original_message_id,
+            'audit_period_beginning': begin,
+            'audit_period_ending': end,
+            'when': now
+        }
+
+        expected = copy.copy(event)
+        expected['region'] = self.region
+        expected['@timestamp'] = now
+        exp_json = json.dumps(
+            expected, cls=elasticsearch_handler.ElasticsearchDateEncoder)
+        expected = json.loads(exp_json)
+
+        self.handler._send_to_elasticsearch(event)
+
+        args = self.post_args[0]
+        self.assertEqual(self.elasticsearch_host, args['url'])
+        actual = json.loads(args['data'])
+        self.assertDictEqual(expected, actual)
+
+    def test_handle_messages_no_cuf(self):
+        exists_msg_id = str(uuid.uuid4())
+        verified_msg_id = str(uuid.uuid4())
+        original_message_id = exists_msg_id
+
+        messages = [
+            MockMessage({
+                'event_type': 'compute.instance.exists',
+                'message_id': exists_msg_id,
+                'payload': {
+                    'audit_period_beginning': '2015-05-03 11:51:11',
+                    'audit_period_ending': '2012-05-04 11:51:11',
+                }
+            }),
+            MockMessage({
+                'event_type': 'compute.instance.exists.verified',
+                'message_id': verified_msg_id,
+                'original_message_id': original_message_id,
+                'payload': {
+                    'audit_period_beginning': '2015-05-03 11:51:11',
+                    'audit_period_ending': '2012-05-04 11:51:11',
+                }
+            })
+        ]
+        env = dict()
+
+        self.handler.handle_messages(messages, env)
+
+        self.assertEqual(2, len(self.post_args))
+
+    def test_handle_messages_with_cuf(self):
+        exists_msg_id = str(uuid.uuid4())
+        verified_msg_id = str(uuid.uuid4())
+        original_message_id = exists_msg_id
+
+        messages = [
+            MockMessage({
+                'event_type': 'compute.instance.exists',
+                'message_id': exists_msg_id,
+                'payload': {
+                    'audit_period_beginning': '2015-05-03 11:51:11',
+                    'audit_period_ending': '2012-05-04 11:51:11',
+                }
+            }),
+            MockMessage({
+                'event_type': 'compute.instance.exists.verified',
+                'message_id': verified_msg_id,
+                'original_message_id': original_message_id,
+                'payload': {
+                    'audit_period_beginning': '2015-05-03 11:51:11',
+                    'audit_period_ending': '2012-05-04 11:51:11',
+                }
+            })
+        ]
+        env = dict()
+        cuf_results = env.setdefault('cufpub.results', dict())
+        cuf_results[verified_msg_id] = dict(error=False, code=None,
+                                            message="Success", service='novae',
+                                            ah_event_id='some_ah_event_id')
+
+        self.handler.handle_messages(messages, env)
+
+        self.assertEqual(3, len(self.post_args))
+        args = self.post_args[2]
+        actual = json.loads(args['data'])
+        self.assertEqual('compute.instance.exists.verified.cuf',
+                         actual['event_type'])
+        self.assertEqual(verified_msg_id, actual['original_message_id'])

--- a/yagi/handler/elasticsearch_handler.py
+++ b/yagi/handler/elasticsearch_handler.py
@@ -1,0 +1,102 @@
+import copy
+from datetime import datetime
+import json
+import logging
+import requests
+
+import pytz
+
+import stackdistiller.distiller
+import yagi
+import yagi.serializer.cuf
+
+
+LOG = logging.getLogger(__name__)
+
+
+# Note: There is a similar class in stacktach-notifiction-utils, however
+# it renders datetime objects as a string with <seconds>.<microseconds>.
+# Elasticsearch doesn't understand microseconds in timestamps so we need
+# a different format. Numeric milliseconds work well.
+class ElasticsearchDateEncoder(json.JSONEncoder):
+    def datetime_ms(self, dt):
+        """Encodes a datetime object as milliseconds since the epoch.
+        :param dt: The datetime to be encoded
+        :return: The datetime as milliseconds since the epoch"""
+        epoch = datetime.utcfromtimestamp(0)
+        if dt.tzinfo is not None:
+            epoch = epoch.replace(tzinfo=pytz.UTC)
+
+        delta = dt - epoch
+
+        seconds = int(delta.total_seconds())
+        ms = (seconds * 1000) + (dt.microsecond / 1000)
+        return ms
+
+    def default(self, o):
+        if isinstance(o, datetime):
+            return self.datetime_ms(o)
+
+        return super(ElasticsearchDateEncoder, self).default(o)
+
+
+class ElasticsearchHandler(yagi.handler.BaseHandler):
+    CONFIG_SECTION = 'elasticsearch'
+    AUTO_ACK = True
+
+    def __init__(self, app=None, queue_name=None):
+        super(ElasticsearchHandler, self).__init__(app=app,
+                                                   queue_name=queue_name)
+        self.region = self.config_get('region')
+        self.elasticsearch_host = self.config_get('elasticsearch_host')
+        dist_conf_file = self.config_get('distiller_config')
+        dist_conf = stackdistiller.distiller.load_config(dist_conf_file)
+        self.distiller = stackdistiller.distiller.Distiller(dist_conf)
+
+    def _send_to_elasticsearch(self, event):
+        if 'compute.instance.exists' == event['event_type']:
+            event['@timestamp'] = event['audit_period_ending']
+        else:
+            event['@timestamp'] = event['when']
+
+        event['region'] = self.region
+
+        json_event = json.dumps(event, cls=ElasticsearchDateEncoder)
+        try:
+            LOG.debug('Sending to Elasticsearch: %s' % json_event)
+            requests.post(self.elasticsearch_host, data=json_event)
+        except Exception:
+            LOG.exception('Error sending event to Elasticsearch')
+
+    def handle_messages(self, messages, env):
+        cuf_pub_results = env.setdefault('cufpub.results', dict())
+        verified_msg_ids = []
+        for payload in self.iterate_payloads(messages, env):
+            try:
+                if 'instance.exists' in payload['event_type']:
+                    LOG.debug('Found event of type: %s' %
+                              payload['event_type'])
+                    event = self.distiller.to_event(payload)
+                    self._send_to_elasticsearch(event.get_event())
+                    if ('compute.instance.exists.verified' ==
+                            payload['event_type']):
+                        verified_msg_ids.append(payload['message_id'])
+            except KeyError:
+                error_msg = 'Malformed Notification: %s' % payload
+                LOG.exception(error_msg)
+                continue
+
+        # Look for successful cuf_pub results and push fake 'events' to ES
+        for msgid in verified_msg_ids:
+            result = cuf_pub_results.get(msgid)
+            if result is not None:
+                if not result['error'] and ('Success' == result['message']):
+                    LOG.debug('Synthesizing .cuf event for ah event: %s' %
+                              result['ah_event_id'])
+                    event = copy.copy(result)
+                    event['when'] = datetime.utcnow().replace(tzinfo=pytz.UTC)
+                    event['original_message_id'] = msgid
+                    event['event_type'] = \
+                        'compute.instance.exists.verified.cuf'
+                    event['message_id'] = event['ah_event_id']
+                    self._send_to_elasticsearch(event)


### PR DESCRIPTION
This commit adds a handler that will push compute.instance.exists,
.verified, and .failed events (distilled) to an Elasticsearch
instance for longer retention and more thorough analysis of any
problems regarding missing events.

Also, if placed in a chain after the cuf_pub_handler, will
generate and push synthetic events corresponding to successfully
published .verified.cuf events.