### PR TITLE
For the Elasticsearch handler, change how the timestamp is created

### DIFF
--- a/tests/unit/test_elasticsearch_handler.py
+++ b/tests/unit/test_elasticsearch_handler.py
@@ -144,7 +144,7 @@ class TestElasticsearchHandler(unittest.TestCase):
 
         expected = copy.copy(event)
         expected['region'] = self.region
-        expected['@timestamp'] = now
+        expected['@timestamp'] = end
         exp_json = json.dumps(
             expected, cls=elasticsearch_handler.ElasticsearchDateEncoder)
         expected = json.loads(exp_json)


### PR DESCRIPTION
Changing how the timestamp is created on the data being sent to
Elasticsearch so it will better align across .exists, .verified,
and .cuf events.