### PR TITLE
Bug Fix for SSL

### DIFF
--- a/yagi/broker/rabbit.py
+++ b/yagi/broker/rabbit.py
@@ -109,7 +109,7 @@ class Broker(object):
                         userid=config("user"),
                         password=config("password"),
                         virtual_host=config("vhost"),
-                        ssl=confbool("ssl"))
+                        ssl=confbool(config("ssl")))
 
         auto_delete = consumer.config("auto_delete") == "True" or False
         durable = consumer.config("durable") == "True" or False


### PR DESCRIPTION
Missing config for ssl.
Additionally in python > 2.6 , we can have ssl parameter as a dictionary containing certificates to be verified instead of Boolean values.
using 'confbool(config("ssl"))' would just assign it true or false values.
This condition is not fixed in this commit.