### PR TITLE
Fix deterministic ID generation in CUF handler.

### DIFF
--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -32,7 +32,8 @@ test_glance_xml_generator_values = {
 
 
 def verified_nova_message_in_cuf_format(values):
-    test_nova_xml_generator_values.update(values)
+    vals = dict(**test_nova_xml_generator_values)
+    vals.update(values)
     cuf_xml = ("""<event xmlns="http://docs.rackspace.com/core/event" """
     """xmlns:nova="http://docs.rackspace.com/event/nova" """
     """version="1" id="%(id)s" resourceId="%(resource_id)s" resourceName="%(resource_name)s" dataCenter="%(data_center)s" region="%(region)s" tenantId="%(tenant_id)s" """
@@ -41,7 +42,7 @@ def verified_nova_message_in_cuf_format(values):
     """resourceType="%(resource_type)s" flavorId="%(flavor_id)s" flavorName="%(flavor_name)s" status="%(status)s" """
     """%(options_string)s """
     """bandwidthIn="%(bandwidth_in)s" bandwidthOut="%(bandwidth_out)s"/>"""
-    """</event>""") % test_nova_xml_generator_values
+    """</event>""") % vals
     return {'payload': cuf_xml}
 
 

--- a/yagi/handler/cuf_pub_handler.py
+++ b/yagi/handler/cuf_pub_handler.py
@@ -30,46 +30,21 @@ class CufPub(yagi.handler.BaseHandler):
     def unescape_strings(self, payload_body):
         return str.replace(str.replace(payload_body, "&lt;", "<"), "&gt;", ">")
 
-    def _generate_new_id(self, original_message_id, event_type):
-        # Generate message_id for new events deterministically from
-        # the original message_id and event type using uuid5 algo.
-        # This will allow any dups to be caught by message_id. (mdragon)
-        if original_message_id:
-            oid = uuid.UUID(original_message_id)
-            return uuid.uuid5(oid, event_type)
-        else:
-            LOG.error("Generating %s, but origional message missing"
-                      " origional_message_id." % event_type)
-            return uuid.uuid4()
-
     def nova_cuf(self, deployment_info, payload):
-        notification = Notification(payload)
-        cuf = notification.convert_to_verified_message_in_cuf_format(
-            {'region': deployment_info['REGION'],
-             'data_center': deployment_info['DATACENTER']})
-        event_type = 'compute.instance.exists.verified.cuf'
-        original_message_id = notification.get_original_message_id()
-        entity = dict(content=cuf,
-                      id=str(self._generate_new_id(original_message_id,
-                             event_type)),
-                      event_type=event_type,
-                      original_message_id=original_message_id)
+        args = dict(region=deployment_info['REGION'],
+                    data_center=deployment_info['DATACENTER'],
+                    event_type='compute.instance.exists.verified.cuf')
+        notification = Notification(payload, **args)
+        entity = notification.to_entity()
         payload_body = yagi.serializer.cuf.dump_item(entity)
         return self.unescape_strings(payload_body)
 
-
     def glance_cuf(self, deployment_info, payload):
-        glance_notification = GlanceNotification(payload)
-        cuf = glance_notification.convert_to_verified_message_in_cuf_format(
-            {'region': deployment_info['DATACENTER'],
-             'data_center': deployment_info['REGION']})
-        event_type = 'image.exists.verified.cuf'
-        original_message_id = glance_notification.get_original_message_id()
-        entity = dict(content=cuf,
-                      id=str(self._generate_new_id(original_message_id,
-                             event_type)),
-                      event_type=event_type,
-                      original_message_id=original_message_id)
+        args = dict(region=deployment_info['REGION'],
+                    data_center=deployment_info['DATACENTER'],
+                    event_type='image.exists.verified.cuf')
+        glance_notification = GlanceNotification(payload, **args)
+        entity = glance_notification.to_entity()
         payload_body = yagi.serializer.cuf.dump_item(entity, service_title="Glance")
         return self.unescape_strings(payload_body)
 

--- a/yagi/handler/notification.py
+++ b/yagi/handler/notification.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import datetime
+import logging
 from yagi.handler.notification_options import NotificationOptions
 from yagi.handler.notification_payload import NotificationPayload, GlanceNotificationPayload
 
@@ -25,12 +26,49 @@ glance_cuf_template_per_image = ("""<event endTime="%(end_time)s" """
 
 atom_hopper_time_format = "%Y-%m-%dT%H:%M:%SZ"
 
+LOG = logging.getLogger(__name__)
 
-class Notification(object):
-    def __init__(self, message):
+
+class BaseNotification(object):
+
+    def __init__(self, message, event_type, region="", data_center=""):
         self.message = message
+        self.event_type = event_type
+        self.region = region
+        self.data_center = data_center
 
-    def _create_cuf_xml(self, deployment_info, json_body):
+    def get_original_message_id(self):
+        return self.message.get('original_message_id', "")
+
+    def generate_new_id(self):
+        # Generate message_id for new events deterministically from
+        # the original message_id and event type using uuid5 algo.
+        # This will allow any dups to be caught by message_id. (mdragon)
+        original_message_id = self.get_original_message_id()
+        if original_message_id:
+            oid = uuid.UUID(original_message_id)
+            return uuid.uuid5(oid, self.event_type)
+        else:
+            LOG.error("Generating %s, but origional message missing"
+                      " origional_message_id." % self.event_type)
+            return uuid.uuid4()
+
+    def convert_to_verified_message_in_cuf_format(self):
+        cuf_xml = self._create_cuf_xml(self.message)
+        return {'payload': cuf_xml}
+
+    def to_entity(self):
+        cuf = self.convert_to_verified_message_in_cuf_format()
+        entity = dict(content=cuf,
+                      id=str(self.generate_new_id()),
+                      event_type=self.event_type,
+                      original_message_id=self.get_original_message_id())
+        return entity
+
+
+class Notification(BaseNotification):
+
+    def _create_cuf_xml(self, json_body):
         payload = NotificationPayload(json_body['payload'])
         notification_options = {'com.rackspace__1__options': payload.options}
         cuf_xml_values = {}
@@ -45,42 +83,26 @@ class Notification(object):
         cuf_xml_values['tenant_id'] = payload.tenant_id
         cuf_xml_values['instance_id'] = payload.instance_id
         cuf_xml_values['instance_name'] = payload.instance_name
-        cuf_xml_values['id'] = uuid.uuid4()
+        cuf_xml_values['id'] = self.generate_new_id()
         cuf_xml_values['flavor_id'] = payload.flavor_id
         cuf_xml_values['flavor_name'] = payload.flavor_name
         cuf_xml_values['status'] = payload.status
-        cuf_xml_values['data_center'] = deployment_info['data_center']
-        cuf_xml_values['region'] = deployment_info['region']
+        cuf_xml_values['data_center'] = self.data_center
+        cuf_xml_values['region'] = self.region
         cuf_xml = nova_cuf_template % cuf_xml_values
         return cuf_xml
 
-    def convert_to_verified_message_in_cuf_format(self, deployment_info):
-        cuf_xml = self._create_cuf_xml(deployment_info, self.message)
-        return {'payload': cuf_xml}
 
-    def get_original_message_id(self):
-        return self.message.get('original_message_id', "")
+class GlanceNotification(BaseNotification):
 
-
-class GlanceNotification(object):
-    def __init__(self, message):
-        self.message = message
-
-    def _create_cuf_xml(self, deployment_info, json_body):
+    def _create_cuf_xml(self, json_body):
         payload = GlanceNotificationPayload(json_body['payload'], atom_hopper_time_format)
         images = payload.images
         cuf = "<events>"
         for image in images:
-            image['data_center'] = deployment_info['data_center']
-            image['region'] = deployment_info['region']
+            image['data_center'] = self.data_center
+            image['region'] = self.region
             cuf_xml = glance_cuf_template_per_image % image
             cuf += cuf_xml
         cuf += "</events>"
         return cuf
-
-    def convert_to_verified_message_in_cuf_format(self, deployment_info):
-        cuf_xml= self._create_cuf_xml(deployment_info, self.message)
-        return {'payload': cuf_xml}
-
-    def get_original_message_id(self):
-        return self.message.get('original_message_id', "")


### PR DESCRIPTION
Message ids for CUF format messages are supposed to be
deterministicly generated via the UUID5 algorithm, to prevent
duplicate copies upstream if the same verified message is
sent to Yagi more than once. The id was being properly generated,
but was being ignored and replaced with a random UUID.

This fixes that issue.