### PR TITLE
Fix unittests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "requests",
         "routes",
         "WebOb",
+        "stackdistiller",
         "python-daemon",
         "BeautifulSoup",
     ],

--- a/tests/unit/test_cufpub.py
+++ b/tests/unit/test_cufpub.py
@@ -2,7 +2,7 @@ import functools
 import unittest
 import uuid
 import httplib2
-import mox
+import mock
 import stubout
 from yagi.handler import http_connection
 import yagi
@@ -28,10 +28,9 @@ class CufPubTests(unittest.TestCase):
 
     def setUp(self):
         self.stubs = stubout.StubOutForTesting()
-        self.mox = mox.Mox()
         config_dict = {
             'atompub': {
-                'url': 'http://127.0.0.1:9000/test/%(event_type)s',
+                'url': 'http://127.0.0.1:9000/test/test_feed',
                 'user': 'user',
                 'key': 'key',
                 'interval': 30,
@@ -52,7 +51,7 @@ class CufPubTests(unittest.TestCase):
                 'method': 'no_auth'
             },
             'cufpub': {
-                'url': 'http://127.0.0.1:9000/test/%(event_type)s',
+                'url': 'http://127.0.0.1:9000/test/test_feed',
                 'user': 'user',
                 'key': 'key',
                 'interval': 30,
@@ -88,9 +87,11 @@ class CufPubTests(unittest.TestCase):
 
     def tearDown(self):
         self.stubs.UnsetAll()
-        self.mox.UnsetStubs()
 
-    def test_notify_for_instance_exists_message(self):
+    @mock.patch('httplib2.Http.request', return_value=(MockResponse(201),
+        """<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"><atom:id>"""
+        """urn:uuid:95347e4d-4737-4438-b774-6a9219d78d2a</atom:id>"""))
+    def test_notify_for_instance_exists_message(self, mock_request):
         original_message_id = '425b23c9-9add-409f-938e-c131f304602a'
         messages = [MockMessage(
             {
@@ -119,7 +120,7 @@ class CufPubTests(unittest.TestCase):
             }
         )]
 
-        body = ("""<?xml version="1.0" encoding="utf-8"?>\n"""
+        cuf_xml_body = ("""<?xml version="1.0" encoding="utf-8"?>\n"""
         """<atom:entry xmlns:atom="http://www.w3.org"""
         """/2005/Atom"><atom:category term="compute.instance."""
         """exists.verified.cuf"></atom:category><atom:category term"""
@@ -136,21 +137,18 @@ class CufPubTests(unittest.TestCase):
         """="SERVER" flavorId="10" flavorName="m1.nano" status="ACTIVE" """
         """osLicenseType="RHEL" bandwidthIn="1001" bandwidthOut"""
         """="19992"/></event></atom:content></atom:entry>""")
-        self.mox.StubOutWithMock(httplib2.Http, """request""")
-        content = ("""<atom:entry xmlns:atom="http://www.w3.org/2005/Atom">"""
-        """<atom:id>urn:uuid:95347e4d-4737-4438-b774-6a9219d78d2a</atom:id""")
-        httplib2.Http.request('http://127.0.0.1:9000/test/%(event_type)s',
-                              'POST', body=body,
-                              headers={'Content-Type': 'application/atom+xml'}
-        ).AndReturn((MockResponse(201), content))
-
-        self.mox.ReplayAll()
 
         self.handler.handle_messages(messages, dict())
 
-        self.mox.VerifyAll()
+        self.assertTrue(mock_request.called)
+        mock_request.assert_called_with('http://127.0.0.1:9000/test/test_feed',
+                                        'POST', body=cuf_xml_body,
+                                         headers={'Content-Type': 'application/atom+xml'})
 
-    def test_notify_for_image_exists_message_for_one_image(self):
+    @mock.patch('httplib2.Http.request', return_value=(MockResponse(201),
+        """<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"><atom:id>"""
+        """urn:uuid:95347e4d-4737-4438-b774-6a9219d78d2a</atom:id>"""))
+    def test_notify_for_image_exists_message_for_one_image(self, mock_request):
         original_message_id = '425b23c9-9add-409f-938e-c131f304602a'
         messages = [MockMessage(
             {"event_type": "image.exists",
@@ -187,28 +185,25 @@ class CufPubTests(unittest.TestCase):
         """<atom:title type="text">Glance"""
         """</atom:title><atom:content type="application/xml"><events><"""
         """event endTime="2013-09-02T23:59:59Z" """
-        """startTime="2013-09-02T16:08:10Z" region="ORD1" """
-        """dataCenter="PREPROD-ORD" type="USAGE" """
-        """id="03eb6990-616d-545f-a7c8-1cd8d03ac730" resourceId="image1" """
+        """startTime="2013-09-02T16:08:10Z" region="PREPROD-ORD" """
+        """dataCenter="ORD1" type="USAGE" """
+        """id="3ec2aa55-1f5c-59b9-b7c9-f05a8dc5b9e3" resourceId="image1" """
         """tenantId="owner1" version="1"> <glance:product """
         """storage="12345" serverId="inst_uuid1" serviceCode="Glance" """
         """serverName="" resourceType="snapshot" version="1"/></event></events>"""
         """</atom:content></atom:entry>""")
 
-        content = ("""<atom:entry xmlns:atom="http://www.w3.org/2005/Atom">"""
-        """<atom:id>urn:uuid:95347e4d-4737-4438-b774-6a9219d78d2a</atom:id""")
-        self.mox.StubOutWithMock(httplib2.Http, 'request')
-        httplib2.Http.request('http://127.0.0.1:9000/test/%(event_type)s',
-                              'POST', body=cuf_xml_body,
-                              headers={'Content-Type': 'application/atom+xml'}
-        ).AndReturn((MockResponse(201), content))
-        self.mox.ReplayAll()
-
         self.handler.handle_messages(messages, dict())
 
-        self.mox.VerifyAll()
+        self.assertTrue(mock_request.called)
+        mock_request.assert_called_with('http://127.0.0.1:9000/test/test_feed',
+                                        'POST', body=cuf_xml_body,
+                                         headers={'Content-Type': 'application/atom+xml'})
 
-    def test_notify_for_image_exists_message_for_more_than_one_image(self):
+    @mock.patch('httplib2.Http.request', return_value=(MockResponse(201),
+        """<atom:entry xmlns:atom="http://www.w3.org/2005/Atom"><atom:id>"""
+        """urn:uuid:95347e4d-4737-4438-b774-6a9219d78d2a</atom:id>"""))
+    def test_notify_for_image_exists_message_for_more_than_one_image(self, mock_request):
         original_message_id = '425b23c9-9add-409f-938e-c131f304602a'
         messages = [MockMessage(
             {"event_type": "image.exists",
@@ -256,33 +251,28 @@ class CufPubTests(unittest.TestCase):
         """<atom:category term="original_message_id:425b23c9-9add-409f-938e-c131f304602a"></atom:category>"""
         """<atom:title type="text">Glance</atom:title><atom:content type="application/xml">"""
         """<events><event endTime="2013-09-02T23:59:59Z" startTime="2013-09-02T"""
-        """16:08:10Z" region="ORD1" dataCenter="PREPROD-ORD" type="USAGE" """
-        """id="03eb6990-616d-545f-a7c8-1cd8d03ac730" resourceId="image1" """
+        """16:08:10Z" region="PREPROD-ORD" dataCenter="ORD1" type="USAGE" """
+        """id="3ec2aa55-1f5c-59b9-b7c9-f05a8dc5b9e3" resourceId="image1" """
         """tenantId="owner1" version="1"> <glance:product storage="12345" """
         """serverId="inst_uuid1" serviceCode="Glance" serverName="" """
         """resourceType="snapshot" version="1"/></event><event """
         """endTime="2013-09-02T16:08:46Z" startTime="2013-09-02T16:05:17Z" """
-        """region="ORD1" dataCenter="PREPROD-ORD" type="USAGE" """
-        """id="03eb6990-616d-545f-a7c8-1cd8d03ac730" resourceId="image2" """
+        """region="PREPROD-ORD" dataCenter="ORD1" type="USAGE" """
+        """id="8809eae4-2e0e-52a6-b95a-a608ee3acb91" resourceId="image2" """
         """tenantId="owner1" version="1"> <glance:product storage="67890" """
         """serverId="inst_uuid2" serviceCode="Glance" serverName="" """
         """resourceType="snapshot" version="1"/></event></events>"""
         """</atom:content></atom:entry>""")
 
-        content = ("""<atom:entry xmlns:atom="http://www.w3.org/2005/Atom">"""
-        """<atom:id>urn:uuid:95347e4d-4737-4438-b774-6a9219d78d2a</atom:id""")
-        self.mox.StubOutWithMock(httplib2.Http, 'request')
-        httplib2.Http.request('http://127.0.0.1:9000/test/%(event_type)s',
-                              'POST', body=cuf_xml_body,
-                              headers={'Content-Type': 'application/atom+xml'}
-        ).AndReturn((MockResponse(201), content))
-        self.mox.ReplayAll()
-
         self.handler.handle_messages(messages, dict())
 
-        self.mox.VerifyAll()
+        self.assertTrue(mock_request.called)
+        mock_request.assert_called_with('http://127.0.0.1:9000/test/test_feed',
+                                        'POST', body=cuf_xml_body,
+                                         headers={'Content-Type': 'application/atom+xml'})
 
-    def test_notify_fails(self):
+    @mock.patch('httplib2.Http.request', return_value=(MockResponse(404), """Bogus, dude!"""))
+    def test_notify_fails(self, mock_request):
         messages = [MockMessage(
             {
                 'event_type': 'compute.instance.exists',
@@ -308,17 +298,13 @@ class CufPubTests(unittest.TestCase):
                      'state_description': ''}
             }
         )]
-        self.called = False
 
-        def mock_request(*args, **kwargs):
-            self.called = True
-            return MockResponse(404), None
-
-        self.stubs.Set(httplib2.Http, 'request', mock_request)
         self.handler.handle_messages(messages, dict())
-        self.assertEqual(self.called, True)
 
-    def test_malformed_message_should_not_raise_exception(self):
+        self.assertTrue(mock_request.called)
+
+    @mock.patch('httplib2.Http.request', return_value=(MockResponse(404), """Bogus, dude!"""))
+    def test_malformed_message_should_not_raise_exception(self, mock_request):
         messages = [MockMessage(
             {
                 'event_type': 'compute.instance.exists',
@@ -340,13 +326,6 @@ class CufPubTests(unittest.TestCase):
                      'deleted_at': ''}
             }
         )]
-        self.called = False
-
-        def mock_request(*args, **kwargs):
-            self.called = True
-            return MockResponse(404), None
-
-        self.stubs.Set(httplib2.Http, 'request', mock_request)
         self.handler.handle_messages(messages, dict())
-        self.assertEqual(self.called, False)
 
+        self.assertFalse(mock_request.called)

--- a/tests/unit/test_elasticsearch_handler.py
+++ b/tests/unit/test_elasticsearch_handler.py
@@ -13,6 +13,35 @@ import yagi.config
 from yagi.handler import elasticsearch_handler
 
 
+TEST_DISTILLER_CONF = [
+{'event_type': 'compute.*',
+  'traits': {'deleted_at': {'fields': 'payload.deleted_at',
+    'type': 'datetime'},
+   'host': {'fields': 'publisher_id',
+    'plugin': {'name': 'split', 'parameters': {'max_split': 1, 'segment': 1}}},
+   'instance_id': {'fields': 'payload.instance_id'},
+   'launched_at': {'fields': 'payload.launched_at', 'type': 'datetime'},
+   'service': {'fields': 'publisher_id', 'plugin': 'split'},
+   'state': {'fields': 'payload.state'},
+   'tenant_id': {'fields': 'payload.tenant_id'},
+   'user_id': {'fields': 'payload.user_id'}}},
+ {'event_type': 'compute.instance.exists',
+  'traits': {'audit_period_beginning': {'fields': 'payload.audit_period_beginning',
+    'type': 'datetime'},
+   'audit_period_ending': {'fields': 'payload.audit_period_ending',
+    'type': 'datetime'},
+   'deleted_at': {'fields': 'payload.deleted_at', 'type': 'datetime'},
+   'host': {'fields': 'publisher_id',
+    'plugin': {'name': 'split', 'parameters': {'max_split': 1, 'segment': 1}}},
+   'instance_id': {'fields': 'payload.instance_id'},
+   'launched_at': {'fields': 'payload.launched_at', 'type': 'datetime'},
+   'service': {'fields': 'publisher_id', 'plugin': 'split'},
+   'state': {'fields': 'payload.state'},
+   'tenant_id': {'fields': 'payload.tenant_id'},
+   'user_id': {'fields': 'payload.user_id'}}}
+]
+
+
 class MockMessage(object):
     def __init__(self, payload):
         self.payload = payload
@@ -68,9 +97,13 @@ class TestElasticsearchHandler(unittest.TestCase):
         def config_with(*args):
             return functools.partial(get, args)
 
+        def load_distiller_conf(filename):
+            return TEST_DISTILLER_CONF
+
         self.patches.append(mock.patch.object(yagi.config, 'config_with',
                                               new=config_with))
         self.patches.append(mock.patch.object(yagi.config, 'get', new=get))
+        self.patches.append(mock.patch.object(stackdistiller.distiller, 'load_config', new=load_distiller_conf))
 
         self.post_args = []
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 setenv = VIRTUAL_ENV={envdir}
 
 commands =
-   nosetests tests 
+   nosetests '{posargs}'
 
 sitepackages = False
 

--- a/yagi/handler/notification.py
+++ b/yagi/handler/notification.py
@@ -40,14 +40,17 @@ class BaseNotification(object):
     def get_original_message_id(self):
         return self.message.get('original_message_id', "")
 
-    def generate_new_id(self):
+    def generate_new_id(self, extra=None):
         # Generate message_id for new events deterministically from
         # the original message_id and event type using uuid5 algo.
         # This will allow any dups to be caught by message_id. (mdragon)
         original_message_id = self.get_original_message_id()
         if original_message_id:
             oid = uuid.UUID(original_message_id)
-            return uuid.uuid5(oid, self.event_type)
+            if extra:
+                return uuid.uuid5(oid, self.event_type + str(extra))
+            else:
+                return uuid.uuid5(oid, self.event_type)
         else:
             LOG.error("Generating %s, but origional message missing"
                       " origional_message_id." % self.event_type)
@@ -100,6 +103,7 @@ class GlanceNotification(BaseNotification):
         images = payload.images
         cuf = "<events>"
         for image in images:
+            image['id'] = self.generate_new_id(extra=image['resource_id'])
             image['data_center'] = self.data_center
             image['region'] = self.region
             cuf_xml = glance_cuf_template_per_image % image

--- a/yagi/handler/notification_payload.py
+++ b/yagi/handler/notification_payload.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import uuid
 import yagi
 
 LOG = logging.getLogger(__name__)
@@ -152,7 +151,6 @@ class GlanceNotificationPayload(object):
         audit_period_ending = payload_json.get('audit_period_ending', "")
         for raw_image in raw_images:
             image = {}
-            image['id'] = uuid.uuid4()
             image['resource_id'] = raw_image.get('id', "")
             image['tenant_id'] = payload_json.get('owner', "")
             created_at = raw_image['created_at']


### PR DESCRIPTION
Fix up CufPub tests. 
Current 'mox' unittests were not actually comparing the returned CUF xml text properly. 
Replaced 'mox' with 'mock', as 'mox' is depreciated. (and poorly documented)  