### PR TITLE
Add discard filter.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,3 +4,4 @@ nose
 notification_utils
 shoebox
 stackdistiller
+unittest2

--- a/tests/unit/test_cufpub.py
+++ b/tests/unit/test_cufpub.py
@@ -370,7 +370,7 @@ class CufPubTests(unittest.TestCase):
             """resourceName="10.69.221.27" tenantId="404" """
             """startTime="2016-06-13T00:00:00Z" endTime="2016-06-13T23:59:59Z" """
             """type="USAGE" dataCenter="ORD1" region="PREPROD-ORD"> <neutron:product """
-            """serviceCode="CloudNetworks" resourceType="IP" ipType="fixed"/> """
+            """serviceCode="CloudNetworks" resourceType="IP" version="1" ipType="fixed"/> """
             """</event></atom:content></atom:entry>"""
         )
 

--- a/tests/unit/test_elasticsearch_handler.py
+++ b/tests/unit/test_elasticsearch_handler.py
@@ -3,7 +3,7 @@ import datetime
 import functools
 import json
 import requests
-import unittest
+import unittest2 as unittest
 import uuid
 
 import mock

--- a/tests/unit/test_shoebox_handler.py
+++ b/tests/unit/test_shoebox_handler.py
@@ -72,7 +72,8 @@ class TestShoeboxHandler(unittest.TestCase):
                 self.assertEquals(sh.cell, 'my_cell')
                 fake_rm = mock.MagicMock()
                 sh.roll_manager = fake_rm
-                payload ={'payload': 'foo'}
+                payload = {'event_type': 'test.thing',
+                           'message_id': '1234-5678'}
                 message = mock.MagicMock(payload=payload)
                 sh.handle_messages([message], {})
                 wrapped = {"region": "my_region",

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -93,6 +93,7 @@ def verified_neutron_pub_ipv4_message_in_cuf_format(values):
         """region="{region}"> """
         """<neutron:product serviceCode="CloudNetworks" """
         """resourceType="{resourceType}" """
+        """version="1" """
         """ipType="{ipType}"/> """
         """</event>"""
     )

--- a/yagi/handler/__init__.py
+++ b/yagi/handler/__init__.py
@@ -86,8 +86,18 @@ class BaseHandler(object):
         return payload
 
     def iterate_payloads(self, messages, env):
+        discard_event_type_list = []
+        try:
+            discard_event_type = yagi.config.get(
+                'discard_filters', self.CONFIG_SECTION)
+            if discard_event_type:
+                discard_event_type_list = [a.strip() for a in discard_event_type.
+                                          split(",")]
+        except (NoOptionError, NoSectionError):
+            pass
         for message in messages:
-            yield self.filter_payload(message.payload, env)
+            if message.payload['event_type'] not in discard_event_type_list:
+                yield self.filter_payload(message.payload, env)
             if self.AUTO_ACK and not message.acknowledged:
                 message.ack()
 

--- a/yagi/handler/elasticsearch_handler.py
+++ b/yagi/handler/elasticsearch_handler.py
@@ -29,8 +29,7 @@ class ElasticsearchDateEncoder(json.JSONEncoder):
 
         delta = dt - epoch
 
-        seconds = int(delta.total_seconds())
-        ms = (seconds * 1000) + (dt.microsecond / 1000)
+        ms = (delta.microseconds + (delta.seconds + delta.days * 24 * 3600) * 10**6) / 10**3
         return ms
 
     def default(self, o):

--- a/yagi/handler/notification.py
+++ b/yagi/handler/notification.py
@@ -27,7 +27,7 @@ glance_cuf_template_per_image = ("""<event endTime="%(end_time)s" """
 
 neutron_pub_ipv4_v1_cuf_template = (
 """<event xmlns="http://docs.rackspace.com/core/event" """
-"""xmlns:neutron="http://docs.rackspace.com/usage/neutron/ipuptime" """
+"""xmlns:neutron="http://docs.rackspace.com/usage/neutron/public-ip-usage" """
 """id="{id}" """
 """version="1" """
 """resourceId="{resourceId}" """


### PR DESCRIPTION
Add filter to allow yagi handlers to discard (ignore, but ack) messages.

Also, fixed unittests broken under python 2.6